### PR TITLE
Added reference to "ValidFor" field to SalesforcePickList class

### DIFF
--- a/src/SalesforceSharp/Models/SalesforcePickList.cs
+++ b/src/SalesforceSharp/Models/SalesforcePickList.cs
@@ -28,5 +28,10 @@
 		/// </summary>
 		/// <value><c>true</c> if default value; otherwise, <c>false</c>.</value>
         public bool DefaultValue { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public string ValidFor { get; set; }
     }
 }

--- a/src/SalesforceSharp/Models/SalesforcePickList.cs
+++ b/src/SalesforceSharp/Models/SalesforcePickList.cs
@@ -30,8 +30,9 @@
         public bool DefaultValue { get; set; }
 
         /// <summary>
-        /// 
+        /// Gets or sets the value of the Base64 encoded Index of the <see cref="SalesforceSharp.Models.SalesforcePickList"/> controlling field.
         /// </summary>
+        /// <value>A Base64 encoded string</value>
         public string ValidFor { get; set; }
     }
 }


### PR DESCRIPTION
I needed to be able to determine from a pick list what its controlling field was.  The "ValidFor" field is a Base64 encoded string which represents the index of the controlling fields value.  When I call GetSObjectDetail it now returns this value under the related items "PickListValues" collection.