### PR TITLE
do not disable TLS 1.3 or allow insecure TLS versions

### DIFF
--- a/src/SalesforceSharp/Security/UsernamePasswordAuthenticationFlow.cs
+++ b/src/SalesforceSharp/Security/UsernamePasswordAuthenticationFlow.cs
@@ -106,7 +106,10 @@ namespace SalesforceSharp.Security
         /// </remarks>
         public AuthenticationInfo Authenticate()
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
+            if (ServicePointManager.SecurityProtocol != 0)
+            {
+                ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+            }
             Uri uri = new Uri(TokenRequestEndpointUrl);
             m_restClient.BaseUrl = uri;
 


### PR DESCRIPTION
Rather than setting the `ServicePointManager.SecurityProtocol` to a specific set of values, this just adds TLS 1.2.  The old approach was enabling the insecure TLS 1.0 and 1.1 protocols globally for all requests made by the application that used this method, and it was also removing TLS 1.3 support.

Also, applications targeting .NET Framework 4.7 or later have a default value of 0 (`SecurityProtocolType.SystemDefault`), which lets the OS control which TLS versions are allowed.  This will allow TLS 1.2 by default, so it does not need to be changed.

The "correct" solution here is not to change the `ServicePointManager.SecurityProtocol` value at all, as it changes global static configuration and that should not be done in a library.  But, I understand the desire to make things "just work", and I think this is a decent compromise.