### PR TITLE
Update target framework, update RestSharp dependency

### DIFF
--- a/src/SalesforceSharp.UnitTests/SalesforceSharp.UnitTests.csproj
+++ b/src/SalesforceSharp.UnitTests/SalesforceSharp.UnitTests.csproj
@@ -49,14 +49,14 @@
     <Reference Include="nunit.framework, Version=3.12.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.12.0\lib\net40\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="RestSharp, Version=105.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\RestSharp.105.0.1\lib\net4\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=106.8.10.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.11.5\lib\net452\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="Rhino.Mocks">
       <HintPath>..\packages\RhinoMocks.3.6.1\lib\net\Rhino.Mocks.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Web" />
     <Reference Include="TestSharp">
       <HintPath>..\packages\TestSharp.1.0.2\lib\net40\TestSharp.dll</HintPath>
     </Reference>

--- a/src/SalesforceSharp.UnitTests/packages.config
+++ b/src/SalesforceSharp.UnitTests/packages.config
@@ -8,7 +8,7 @@
   <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net472" />
   <package id="NUnit.Extension.TeamCityEventListener" version="1.0.6" targetFramework="net472" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.8.0" targetFramework="net472" />
-  <package id="RestSharp" version="105.0.1" targetFramework="net40" />
+  <package id="RestSharp" version="106.11.5" targetFramework="net472" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net40" />
   <package id="TestSharp" version="1.0.2" targetFramework="net40" />
 </packages>

--- a/src/SalesforceSharp/SalesforceSharp.csproj
+++ b/src/SalesforceSharp/SalesforceSharp.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SalesforceSharp</RootNamespace>
     <AssemblyName>SalesforceSharp</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -48,11 +48,12 @@
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.6.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="RestSharp, Version=105.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.105.0.1\lib\net4\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=106.8.10.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.11.5\lib\net452\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/SalesforceSharp/packages.config
+++ b/src/SalesforceSharp/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="HelperSharp" version="0.0.4.1" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="6.0.6" targetFramework="net45" />
-  <package id="RestSharp" version="105.0.1" targetFramework="net45" />
+  <package id="RestSharp" version="106.11.5" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
RestSharp minimum target framework is 4.5.2, so I updated to that instead of doing a large jump to 4.7.2.