### PR TITLE
Upgraded the Default Api Version to v50.0

### DIFF
--- a/src/SalesforceSharp.UnitTests/SalesforceClientTest.cs
+++ b/src/SalesforceSharp.UnitTests/SalesforceClientTest.cs
@@ -21,7 +21,7 @@ namespace SalesforceSharp.UnitTests
         public void Constructor_NoArgs_DefaultValues()
         {
             var target = new SalesforceClient();
-            Assert.AreEqual("v28.0", target.ApiVersion);
+            Assert.AreEqual("v50.0", target.ApiVersion);
             Assert.IsNull(target.InstanceUrl);
             Assert.IsFalse(target.IsAuthenticated);
         }

--- a/src/SalesforceSharp/SalesforceClient.cs
+++ b/src/SalesforceSharp/SalesforceClient.cs
@@ -43,7 +43,7 @@ namespace SalesforceSharp
         protected internal SalesforceClient(IRestClient restClient)
         {
             m_restClient = restClient;
-            ApiVersion = "v28.0";
+            ApiVersion = "v50.0";
             m_deserializer = new DynamicJsonDeserializer();
             genericJsonDeserializer = new GenericJsonDeserializer(new SalesforceContractResolver(false));
             updateJsonSerializer = new GenericJsonSerializer(new SalesforceContractResolver(true));
@@ -55,7 +55,7 @@ namespace SalesforceSharp
         /// Gets or sets the API version.
         /// </summary>
         /// <remarks>
-        /// The default value is v28.0.
+        /// The default value is v50.0.
         /// </remarks>
         /// <value>
         /// The API version.


### PR DESCRIPTION
Since Salesforce is ending support for older versions of the API, I have updated the library to use the current latest version of the Rest API (v50.0).

All Unit tests passed except for the `GetRawBytes_ValidRecord` test which simply needs the `Assert.AreEqual(target.ApiCallsLimit, 15000)` default API Calls value changed.  In my case, this value was not 15000...I did not modify this as I am assuming this value will need modified for an individual account's current limitations.

Thanks for putting such a great and helpful library out there.  Our project benefits greatly from SalesforceSharp.